### PR TITLE
Documentação Javadoc para OrderState

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,48 @@ Pro components used in the starter are :
  - [Vaadin Confirm Dialog](https://vaadin.com/components/vaadin-confirm-dialog)
 
  Also the tests are created using [Testbench](https://vaadin.com/testbench) library.
+
+## Javadoc: OrderState
+package com.vaadin.starter.bakery.backend.data;
+
+import java.util.Locale;
+import com.vaadin.flow.shared.util.SharedUtil;
+
+/**
+ * Representa os diferentes estados possíveis de um pedido
+ * na aplicação da pastelaria.
+ *
+ * <p>Os estados refletem o ciclo de vida de um pedido, desde
+ * a sua criação até à entrega ou cancelamento.</p>
+ */
+public enum OrderState {
+
+    /** Pedido recém-criado e ainda não confirmado. */
+    NEW,
+
+    /** Pedido confirmado e em preparação. */
+    CONFIRMED,
+
+    /** Pedido pronto para ser entregue. */
+    READY,
+
+    /** Pedido entregue ao cliente. */
+    DELIVERED,
+
+    /** Pedido com um problema (ex.: pagamento, produto em falta). */
+    PROBLEM,
+
+    /** Pedido cancelado. */
+    CANCELLED;
+
+    /**
+     * Devolve o nome do estado em formato legível para o utilizador.
+     * Por exemplo, {@code READY} torna-se "Ready".
+     *
+     * @return uma versão legível do identificador do estado
+     */
+    public String getDisplayName() {
+        return SharedUtil.capitalize(name().toLowerCase(Locale.ENGLISH));
+    }
+}
+


### PR DESCRIPTION
Este Pull Request adiciona comentários Javadoc ao enum OrderState, explicando o propósito de cada estado e o funcionamento do método getDisplayName().

- Facilita a manutenção futura;
- Melhora a legibilidade do código;
- Contribui para boas práticas de documentação.